### PR TITLE
safety-check [undefined, undefined, undefined] exhibits

### DIFF
--- a/components/user/user.service.js
+++ b/components/user/user.service.js
@@ -11,7 +11,7 @@ export async function getRandomUserExhibits(token, count) {
     filterExhibits(res.exhibits)
   );
 
-  const randomExhibits = Array(count)
+  const randomExhibits = Array(Math.min(exhibitNames, count))
     .fill()
     .map(() => exhibitNames[Math.floor(Math.random() * exhibitNames.length)]);
 


### PR DESCRIPTION
…which when used with randomExhibitImages.length === 0 will return true, which we don't want

See [this Slack](https://vana-org.slack.com/archives/C04KBT99TBM/p1674087593585059?thread_ts=1674082548.839979&cid=C04KBT99TBM) or [VAN-565](https://linear.app/vana-team/issue/VAN-565/show-an-error-message-when-user-has-no-model)