### PR TITLE
feat: use fast inference

### DIFF
--- a/components/prompt/Generator.js
+++ b/components/prompt/Generator.js
@@ -7,12 +7,15 @@ import homeStyles from "styles/Home.module.css";
 const meRegex = /\bme\b/i;
 
 const PROMPT_LIMIT = 16;
-const MINIMUM_CREDITS = 10;
 
 // Number of "text to image" samples generated per request.
-export const GENERATED_SAMPLES = 10;
+// This is hard-coded to four because that's what POSTing to /images/generations produces.
+// https://vana.gitbook.io/api/rest-api-v0/generating-images#text-to-image
+export const GENERATED_SAMPLES = 4;
 
-const Generator = ({ authToken, userBalance, onSubmit }) => {
+const MINIMUM_CREDITS = GENERATED_SAMPLES;
+
+const Generator = ({ authToken, userBalance, onSubmit, onSuccess, onFailure }) => {
   const auth = useAuth();
   const [prompt, setPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -33,19 +36,19 @@ const Generator = ({ authToken, userBalance, onSubmit }) => {
     setIsLoading(true);
 
     try {
-      const { success } = await vanaPost(
-        `jobs/text-to-image`,
+      onSubmit();
+      const { success, message } = await vanaPost(
+        `images/generations`,
         {
           prompt: prompt.replace(meRegex, "{target_token}"),
-          exhibit_name: "text-to-image",
-          n_samples: GENERATED_SAMPLES,
-          seed: -1,
         },
         authToken
       );
 
       if (success) {
-        onSubmit();
+        onSuccess();
+      } else {
+        throw new Error(message);
       }
     } catch (e) {
       let message = "An error occurred while generating the image"
@@ -53,12 +56,10 @@ const Generator = ({ authToken, userBalance, onSubmit }) => {
         message = `${e.message}. Try again with a different prompt.`
       }
       setErrorMessage(message);
+      onFailure();
     } finally {
-      // Reset the form after 3 seconds
-      setTimeout(() => {
-        setPrompt("");
-        setIsLoading(false);
-      }, 3000);
+      setPrompt("");
+      setIsLoading(false);
     }
   };
 
@@ -108,7 +109,7 @@ const Generator = ({ authToken, userBalance, onSubmit }) => {
             <>Create {GENERATED_SAMPLES} images (~7 mins)</>
           )}
         </button>
-        <div className="text-gray text-3">Each attempt is 10 credits</div>
+        <div className="text-gray text-3">Each attempt is {GENERATED_SAMPLES} credits</div>
       </form>
 
       {typeof userBalance !== "undefined" && userBalance < MINIMUM_CREDITS && (

--- a/components/prompt/Generator.js
+++ b/components/prompt/Generator.js
@@ -106,7 +106,7 @@ const Generator = ({ authToken, userBalance, onSubmit, onSuccess, onFailure }) =
           {isLoading ? (
             <Spinner />
           ) : (
-            <>Create {GENERATED_SAMPLES} images (~7 mins)</>
+            <>Create {GENERATED_SAMPLES} images (~20 seconds)</>
           )}
         </button>
         <div className="text-gray text-3">Each attempt is {GENERATED_SAMPLES} credits</div>

--- a/components/prompt/Generator.js
+++ b/components/prompt/Generator.js
@@ -98,6 +98,7 @@ const Generator = ({ authToken, userBalance, onSubmit, onSuccess, onFailure }) =
         <button
           type="submit"
           disabled={
+            isLoading ||
             userBalance < MINIMUM_CREDITS ||
             (!validPrompt && prompt.length > PROMPT_LIMIT && isSubmitted)
           }

--- a/components/prompt/PromptLoader.js
+++ b/components/prompt/PromptLoader.js
@@ -34,7 +34,7 @@ export const PromptLoader = () => (
         <button type="submit" className={homeStyles.primaryButton} disabled>
           <>Create {GENERATED_SAMPLES} images (~7 mins)</>
         </button>
-        <div className="text-gray text-3">Each attempt is 10 credits</div>
+        <div className="text-gray text-3">Each attempt is {GENERATED_SAMPLES} credits</div>
       </form>
     </section>
 

--- a/components/prompt/PromptLoader.js
+++ b/components/prompt/PromptLoader.js
@@ -32,7 +32,7 @@ export const PromptLoader = () => (
           disabled
         />
         <button type="submit" className={homeStyles.primaryButton} disabled>
-          <>Create {GENERATED_SAMPLES} images (~7 mins)</>
+          <>Create {GENERATED_SAMPLES} images (~20 seconds)</>
         </button>
         <div className="text-gray text-3">Each attempt is {GENERATED_SAMPLES} credits</div>
       </form>

--- a/pages/create/index.js
+++ b/pages/create/index.js
@@ -49,6 +49,13 @@ export default function CreatePage() {
     updateGeneratorCount(expectedGeneratorCount + GENERATED_SAMPLES);
   }, [textToImageExhibitImages]);
 
+  const handleGenerationFailure = useCallback(() => {
+    let expectedGeneratorCount =
+      parseInt(window.localStorage.getItem("expectedGeneratorCount")) || 0;
+
+    updateGeneratorCount(Math.max(0, expectedGeneratorCount - GENERATED_SAMPLES));
+  });
+
   // Get a list of user's exhibits
   const populateUserExhibits = useCallback(async (token) => {
     const images = await getUserExhibits(token);
@@ -78,7 +85,7 @@ export default function CreatePage() {
     setUserBalance(balance);
   }, []);
 
-  useEffect(() => {
+  const refreshUser = useCallback(() => {
     if (!authToken) {
       router.replace("/login");
       return;
@@ -103,7 +110,9 @@ export default function CreatePage() {
         setLoading(false);
       }
     })();
-  }, [authToken]);
+  }, [authToken])
+
+  useEffect(refreshUser, [authToken]);
 
   useEffect(() => {
     const expectedGeneratorCount =
@@ -142,6 +151,8 @@ export default function CreatePage() {
                 userBalance={userBalance}
                 authToken={authToken}
                 onSubmit={handleGenerationSubmit}
+                onSuccess={refreshUser}
+                onFailure={handleGenerationFailure}
               />
             </Prompt>
           )}

--- a/pages/create/index.js
+++ b/pages/create/index.js
@@ -68,7 +68,9 @@ export default function CreatePage() {
     async function refreshImages() {
       const images = await getTextToImageUserExhibits(token);
 
-      setTextToImageExhibitImages(images);
+      if (images.length > textToImageExhibitImages.length) {
+        setTextToImageExhibitImages(images);
+      }
     }
 
     refreshImages();
@@ -76,7 +78,7 @@ export default function CreatePage() {
     const interval = setInterval(refreshImages, 60000);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [textToImageExhibitImages]);
 
   // Get the user balance
   const populateUserBalance = useCallback(async (token) => {


### PR DESCRIPTION
### Description

Similar to https://github.com/vana-com/vana-mit-hackathon/pull/2. This uses the https://api.vana.com/api/v0/images/generations API to generate four images in <20 seconds.

Keeping `localStorage.getItem("expectedGeneratorCount")` accurate is probably the most sensitive part of these changes.

I removed the three-second delay before resetting the form, after submitting a prompt. It felt like a clunky UX, especially since the images are already loaded by that point.

### Tested

I tested locally against the production API. I tested error cases (flirtatious text, not enough credits) and error handling worked correctly.

### Related issues

- Fixes #[VAN-577](https://linear.app/vana-team/issue/VAN-577/migrate-portrait-demo-to-use-fast-inference)

### Backwards compatibility

This does not introduce any incompatibilities.
