### PR TITLE
feat: remove loading images

### DIFF
--- a/components/prompt/Generator.js
+++ b/components/prompt/Generator.js
@@ -15,7 +15,7 @@ export const GENERATED_SAMPLES = 4;
 
 const MINIMUM_CREDITS = GENERATED_SAMPLES;
 
-const Generator = ({ authToken, userBalance, onSubmit, onSuccess, onFailure }) => {
+const Generator = ({ authToken, userBalance, onSuccess }) => {
   const auth = useAuth();
   const [prompt, setPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -36,8 +36,7 @@ const Generator = ({ authToken, userBalance, onSubmit, onSuccess, onFailure }) =
     setIsLoading(true);
 
     try {
-      onSubmit();
-      const { success, message } = await vanaPost(
+      const { success, message, data } = await vanaPost(
         `images/generations`,
         {
           prompt: prompt.replace(meRegex, "{target_token}"),
@@ -46,17 +45,21 @@ const Generator = ({ authToken, userBalance, onSubmit, onSuccess, onFailure }) =
       );
 
       if (success) {
-        onSuccess();
+        if (data.length < GENERATED_SAMPLES) {
+          throw new Error(`Received ${data.length} images, but ${GENERATED_SAMPLES} were expected.`);
+        } else {
+          onSuccess();
+        }
       } else {
         throw new Error(message);
       }
     } catch (e) {
-      let message = "An error occurred while generating the image"
+      let message = "An error occurred while generating the image."
       if (e.statusCode === 400) {
         message = `${e.message}. Try again with a different prompt.`
       }
       setErrorMessage(message);
-      onFailure();
+      console.error(e);
     } finally {
       setPrompt("");
       setIsLoading(false);

--- a/components/prompt/Generator.js
+++ b/components/prompt/Generator.js
@@ -45,10 +45,12 @@ const Generator = ({ authToken, userBalance, onSuccess }) => {
       );
 
       if (success) {
+        // Tell the parent component the user has new data to load
+        onSuccess();
+
         if (data.length < GENERATED_SAMPLES) {
+          // TODO: this doesn't get displayed, because the parent re-renders due to onSuccess, fix this
           throw new Error(`Received ${data.length} images, but ${GENERATED_SAMPLES} were expected.`);
-        } else {
-          onSuccess();
         }
       } else {
         throw new Error(message);

--- a/components/prompt/Prompt.js
+++ b/components/prompt/Prompt.js
@@ -7,18 +7,14 @@ import config from "config";
 export const Prompt = ({
   children,
   userExhibits,
-  expectedGeneratorCount,
   textToImageExhibitImages,
 }) => {
   const handleCreate = useCallback(() => {
     window.open("https://portrait.vana.com/create", "_blank").focus();
   }, []);
 
-  const generationDiff =
-    expectedGeneratorCount - textToImageExhibitImages.length;
-
   const noTextToImageExhibitImages =
-    textToImageExhibitImages.length === 0 && generationDiff <= 0;
+    textToImageExhibitImages.length === 0;
 
   if (userExhibits.length === 0) {
     return (
@@ -67,13 +63,6 @@ export const Prompt = ({
         ) : (
           <div className={promptStyles.gallery}>
             {/* placeholder gallery for an awaiting prompt job */}
-            {generationDiff > 0
-              ? new Array(generationDiff).fill().map((_, i) => (
-                  <div key={i} className={promptStyles.galleryImageLoading}>
-                    <Spinner />
-                  </div>
-                ))
-              : undefined}
 
             {/* all prompt results */}
             {textToImageExhibitImages.map((image, i) => (

--- a/pages/create/index.js
+++ b/pages/create/index.js
@@ -38,19 +38,11 @@ export default function CreatePage() {
 
   // Get Text to Image exhibit images
   const populateTextToImageExhibits = useCallback(async (token) => {
-    async function refreshImages() {
-      const images = await getTextToImageUserExhibits(token);
+    const images = await getTextToImageUserExhibits(token);
 
-      if (images.length > textToImageExhibitImages.length) {
-        setTextToImageExhibitImages(images);
-      }
+    if (images.length > textToImageExhibitImages.length) {
+      setTextToImageExhibitImages(images);
     }
-
-    refreshImages();
-
-    const interval = setInterval(refreshImages, 60000);
-
-    return () => clearInterval(interval);
   }, [textToImageExhibitImages]);
 
   // Get the user balance

--- a/pages/create/index.js
+++ b/pages/create/index.js
@@ -11,7 +11,6 @@ import {
   getTextToImageUserExhibits,
   getUserExhibits,
   getUserBalance,
-  GENERATED_SAMPLES,
   useAuth,
 } from "components";
 
@@ -29,32 +28,6 @@ export default function CreatePage() {
   const [userExhibits, setUserExhibits] = useState([]);
 
   const [loading, setLoading] = useState();
-
-  const [expectedGeneratorCount, setExpectedGeneratorCount] = useState(0);
-
-  const updateGeneratorCount = useCallback((count) => {
-    window.localStorage.setItem("expectedGeneratorCount", count);
-
-    setExpectedGeneratorCount(count);
-  }, []);
-
-  const handleGenerationSubmit = useCallback(() => {
-    let expectedGeneratorCount =
-      parseInt(window.localStorage.getItem("expectedGeneratorCount")) || 0;
-
-    if (expectedGeneratorCount < textToImageExhibitImages.length) {
-      expectedGeneratorCount = textToImageExhibitImages.length;
-    }
-
-    updateGeneratorCount(expectedGeneratorCount + GENERATED_SAMPLES);
-  }, [textToImageExhibitImages]);
-
-  const handleGenerationFailure = useCallback(() => {
-    let expectedGeneratorCount =
-      parseInt(window.localStorage.getItem("expectedGeneratorCount")) || 0;
-
-    updateGeneratorCount(Math.max(0, expectedGeneratorCount - GENERATED_SAMPLES));
-  });
 
   // Get a list of user's exhibits
   const populateUserExhibits = useCallback(async (token) => {
@@ -116,13 +89,6 @@ export default function CreatePage() {
 
   useEffect(refreshUser, [authToken]);
 
-  useEffect(() => {
-    const expectedGeneratorCount =
-      parseInt(window.localStorage.getItem("expectedGeneratorCount")) || 0;
-
-    updateGeneratorCount(expectedGeneratorCount);
-  }, []);
-
   return (
     <>
       <Head>
@@ -145,16 +111,13 @@ export default function CreatePage() {
             <PromptLoader />
           ) : (
             <Prompt
-              expectedGeneratorCount={expectedGeneratorCount}
               textToImageExhibitImages={textToImageExhibitImages}
               userExhibits={userExhibits}
             >
               <Generator
                 userBalance={userBalance}
                 authToken={authToken}
-                onSubmit={handleGenerationSubmit}
                 onSuccess={refreshUser}
-                onFailure={handleGenerationFailure}
               />
             </Prompt>
           )}


### PR DESCRIPTION
### Description

Now that we're using fast inference, the loading/placeholder images aren't particularly important. We've been seeing bugs where we predict the number of pending images incorrectly and confuse the user. This removes the placeholder images for a better UX.

It also creates an error state in the console (bug currently prevents it in the UI) when the API doesn't return the expected number of images (i.e., zero instead of four).

### Tested

Tested locally against the production API.

### Backwards compatibility

UI change only
