### PR TITLE
Use updated exhibits endpoint response

### DIFF
--- a/components/prompt/Prompt.js
+++ b/components/prompt/Prompt.js
@@ -69,8 +69,11 @@ export const Prompt = ({
 
             {/* all prompt results */}
             {textToImageExhibitImages.map((image, i) => (
-              <div key={`${image}-${i}`} className={promptStyles.galleryImage}>
-                <img src={image} key={i} />
+              <div
+                key={`${image.name}-${i}`}
+                className={promptStyles.galleryImage}
+              >
+                <img src={image.url} key={i} />
               </div>
             ))}
           </div>

--- a/components/user/user.service.js
+++ b/components/user/user.service.js
@@ -2,7 +2,7 @@ import { vanaGet, vanaPost } from "api";
 
 export async function getTextToImageUserExhibits(token, limit) {
   return vanaGet("account/exhibits/text-to-image", {}, token, { limit }).then(
-    (res) => res.urls
+    (res) => res.files
   );
 }
 

--- a/config.js
+++ b/config.js
@@ -3,7 +3,9 @@ const config = {
   STRIPE_PRODUCT_100_CREDITS: "price_1MFSirJlfQgmiz8ARWF0hDvZ",
   STRIPE_PRODUCT_250_CREDITS: "price_1MFSiDJlfQgmiz8AkVLSaYvw",
   REMIX_SINGLE_CREDIT_PRICE: 0.1,
-  VANA_API_URL: "https://api.vana.com/api/v0",
+  VANA_API_URL: `${
+    process.env.NEXT_PUBLIC_VANA_API_URL || "https://api.vana.com"
+  }/api/v0`,
   VANA_GITHUB_URL: "https://github.com/corsali/vana-portrait-demo",
   VANA_PORTRAIT_URL: "https://portrait.vana.com",
   VANA_SUPPORT_EMAIL: "support@vana.com",

--- a/pages/create/index.js
+++ b/pages/create/index.js
@@ -45,7 +45,6 @@ export default function CreatePage() {
   const populateTextToImageExhibits = useCallback(
     async (token) => {
       const images = await getTextToImageUserExhibits(token, 9);
-
       if (images.length > textToImageExhibitImages.length) {
         setTextToImageExhibitImages(images);
       }

--- a/pages/gallery/index.js
+++ b/pages/gallery/index.js
@@ -102,10 +102,10 @@ export default function GalleryPage() {
                         ))
                     : textToImageExhibitImages.map((image, i) => (
                         <div
-                          key={`${image}-${i}`}
+                          key={`${image.name}-${i}`}
                           className={galleryStyles.galleryImage}
                         >
-                          <img src={image} key={i} />
+                          <img src={image.url} key={i} />
                         </div>
                       ))}
                 </div>


### PR DESCRIPTION
Do not merge until https://github.com/corsali/vana-api/pull/34 is merged.

The `/exhibits` endpoint response has been changed. Update Studio UI accordingly.
```
{
  success: true,
  files: [
    {
      name: "cyberpunk_11.png",
      path: "kahtaf@vana.com/exhibits/cyberpunk/cyberpunk_11.png"
      size: 2147483648,
      created: 1675696313619
      url: <presigned GCS URL>
    }
  ]
}
```